### PR TITLE
♻️ Use flat format for building record tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Supports structured data extraction for REDCap projects
 
 ```Python
-from redcap import REDCapStudy
+from d3b_redcap_api.redcap import REDCapStudy
 
 
 r = REDCapStudy("https://redcap.chop.edu/api/", PROJECT_API_TOKEN)

--- a/tests/records_tree.json
+++ b/tests/records_tree.json
@@ -200,6 +200,44 @@
                         ]
                     }
                 }
+            },
+            "3": {
+                "1": {
+                    "diagnosis_complete": {
+                        "py/set": [
+                            "Incomplete"
+                        ]
+                    }
+                }
+            }
+        },
+        "treatment": {
+            "1": {
+                "1": {
+                    "treatment_complete": {
+                        "py/set": [
+                            "Incomplete"
+                        ]
+                    }
+                }
+            },
+            "2": {
+                "1": {
+                    "treatment_complete": {
+                        "py/set": [
+                            "Incomplete"
+                        ]
+                    }
+                }
+            },
+            "3": {
+                "1": {
+                    "treatment_complete": {
+                        "py/set": [
+                            "Incomplete"
+                        ]
+                    }
+                }
             }
         },
         "update": {
@@ -215,6 +253,24 @@
                             "6 Month Update"
                         ]
                     },
+                    "update_complete": {
+                        "py/set": [
+                            "Incomplete"
+                        ]
+                    }
+                }
+            },
+            "2": {
+                "1": {
+                    "update_complete": {
+                        "py/set": [
+                            "Incomplete"
+                        ]
+                    }
+                }
+            },
+            "3": {
+                "1": {
                     "update_complete": {
                         "py/set": [
                             "Incomplete"
@@ -372,8 +428,8 @@
                     },
                     "family_member": {
                         "py/set": [
-                            "Father",
-                            "Paternal Grandmother"
+                            "Paternal Grandmother",
+                            "Father"
                         ]
                     },
                     "father_what_type_of_cancer": {
@@ -426,6 +482,15 @@
     },
     "specimens_arm_1": {
         "specimen": {
+            "1": {
+                "1": {
+                    "specimen_complete": {
+                        "py/set": [
+                            "Incomplete"
+                        ]
+                    }
+                }
+            },
             "2": {
                 "1": {
                     "enrollment_type2": {
@@ -451,6 +516,15 @@
                     "specimen_type": {
                         "py/set": [
                             "Maternal"
+                        ]
+                    }
+                }
+            },
+            "3": {
+                "1": {
+                    "specimen_complete": {
+                        "py/set": [
+                            "Incomplete"
                         ]
                     }
                 }


### PR DESCRIPTION
eav format ignores requests to include data access group information,
so we have to switch to requesting the flat record format.
The eav method will stay in for debugging purposes.